### PR TITLE
Fix linking issue with fmt library in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(THIRD_PARTY_LIBS
         ${GTEST_BOTH_LIBRARIES}
         rerun_sdk
         ${PCL_LIBRARIES}
+        fmt
         )
 
 


### PR DESCRIPTION
Issue:
` 
undefined reference to symbol '_ZN3fmt2v86detail18throw_format_errorEPKc'
/usr/bin/ld: /lib/x86_64-linux-gnu/libfmt.so.8: error adding symbols: DSO missing from command line
`

Fixed the linking issue with fmt library in CMakeLists.txt

Resolves issue #2.

